### PR TITLE
Ready functie die pas resolved wanneer de dress klaar is

### DIFF
--- a/test/vl-select.test.html
+++ b/test/vl-select.test.html
@@ -237,6 +237,13 @@
         });
         element1.dress();
       });
+
+      test('wanneer het vl-select element volledig klaar is resolved de ready functie', (done) => {
+        const element1 = fixture('vl-select-fixture');
+        element1.dress();
+        element1.ready().then(() => done());
+      });
+
     });
   </script>
 </body>

--- a/vl-select.src.js
+++ b/vl-select.src.js
@@ -224,11 +224,20 @@ export class VlSelect extends NativeVlElement(HTMLSelectElement) {
         vl.select.dress(this, params);
 
         (async () => {
-          await awaitUntil(() => this._dressed);
+          await this.ready();
           this.dispatchEvent(new CustomEvent(this.readyEvent));
         })();
       }
     });
+  }
+
+  /**
+   * Geeft een promise die 'resolved' wanneer de select initialisatie klaar is.
+   *
+   * @returns {Promise} De promise
+   */
+  async ready() {
+    await awaitUntil(() => this._dressed === true);
   }
 
   /**


### PR DESCRIPTION
Gewoon een idee om de asynchroniteit van de component te verbeteren.

De functie laat afnemers toe te wachten tot de component 'ready' is om daarna hiermee aan de slag te gaan.

Als de afnemer LitElement gebruikt zou het volgende kunnen voor de component die de vl-ui-select gebruikt als sub/child component:

```
  async _getUpdateComplete() {
    await super._getUpdateComplete();
    await this.shadowRoot.querySelector('#mySelect').ready();
  }
```

Zie lit documentatie voor meer info ivm overriden van _updateComplete_: https://lit-element.polymer-project.org/guide/lifecycle#updatecomplete

Bv in bestaande testen waar we reeds `await myComponent.updateComplete` doen is er geen bijkomende logica nodig om te kijken of de select 'klaar' is